### PR TITLE
Encode "key" properties for couchr-node

### DIFF
--- a/couchr-node.js
+++ b/couchr-node.js
@@ -93,6 +93,13 @@ exports.request = function (method, url, /*opt*/data, /*opt*/opt, callback) {
         headers['Content-Length'] = data.length;
     }
     else if (data) {
+        // properly encode "key" properties as JSON
+        ['key', 'keys', 'startkey', 'endkey'].forEach(function(key) {
+            if (data[key] != null) {
+                data[key] = JSON.stringify(data[key]);
+            }
+        });
+
         path = parsed.pathname + '?' + querystring.stringify(data);
         data = null;
         headers['Content-Length'] = 0;


### PR DESCRIPTION
At present if you make a request such as:

```
couchr.get('url', { key: ['x', 'y'] }, function(err) { ... });
```

... it fails to encode the key correctly.
