### PR TITLE
A way to pass a session cookie to the request, via opt.Cookie

### DIFF
--- a/couchr-node.js
+++ b/couchr-node.js
@@ -109,7 +109,9 @@ exports.request = function (method, url, /*opt*/data, /*opt*/opt, callback) {
         var enc = new Buffer(parsed.auth).toString('base64');
         headers.Authorization = "Basic " + enc;
     }
-
+    if (opt.Cookie) {
+        headers.Cookie = opt.Cookie;
+    }
     var proto = (parsed.protocol === 'https:') ? https: http;
 
     var request = proto.request({


### PR DESCRIPTION
One needs to be able to pass a cookie to the request. This allows one to be passed via opt.Cookie
