### PR TITLE
Guard against null being explicitly passed to opt

### DIFF
--- a/couchr-node.js
+++ b/couchr-node.js
@@ -71,6 +71,9 @@ exports.request = function (method, url, /*opt*/data, /*opt*/opt, callback) {
         callback = data;
         data = null;
     }
+
+    opt = opt || {};
+
     var parsed = urlParse(url);
     var path = parsed.path;
     var headers = {


### PR DESCRIPTION
If opt is falsey, initialise it to an empty object. This allows the tests later on to work without NPEing.
