### PR TITLE
Fix COPY in node, and relax events in browser globals.

### DIFF
--- a/couchr-browser.js
+++ b/couchr-browser.js
@@ -12,7 +12,7 @@
     }
     else {
         root.couchr = {};
-        factory(root.couchr, events, jQuery); // Browser globals
+        factory(root.couchr, root.events, jQuery); // Browser globals
     }
 
 }(this, function (exports, events, $) {

--- a/couchr-node.js
+++ b/couchr-node.js
@@ -96,6 +96,8 @@ exports.request = function (method, url, /*opt*/data, /*opt*/opt, callback) {
             headers['Content-Type'] = 'application/json';
         }
         headers['Content-Length'] = data.length;
+    } else if (method === 'COPY') {
+        headers['Destination'] = opt.headers['Destination'];
     }
     else if (data) {
         // properly encode "key" properties as JSON


### PR DESCRIPTION
Two small fixes. Just making sure the Destination header actually gets sent to the request in node. And for the browser global version relax events if it is undefined. 
