### PR TITLE
added stringify key, keys, etc. values for GET requests in the browser

### DIFF
--- a/couchr-browser.js
+++ b/couchr-browser.js
@@ -131,6 +131,15 @@
         if (data) {
             try {
                 if (method === 'GET' || method === 'HEAD') {
+	
+					// Copied here from line 107-113 of couchr-node.js
+			        // properly encode "key" properties as JSON
+			        ['key', 'keys', 'startkey', 'endkey'].forEach(function(key) {
+			            if (data[key] != null) {
+			                data[key] = JSON.stringify(data[key]);
+			            }
+			        });
+			
                     options.data = exports.stringifyQuery(data);
                 }
                 else {


### PR DESCRIPTION
Caolan,
I created a wrapper for couchrs' request method provided in couchr-browser.js and couchr-node.js. When creating a query hash for a view request in node.js I had no problem getting the result but the browser implementation of the same query returned a badly formatted query. I copied the code fragment on line 107-113 in couchr-node.js to couchr-browser.js and things worked well after that. I could do the transformation in my wrapper but the clean separation of couchr felt like it belongs there.
-Ron
